### PR TITLE
Added command to update pip

### DIFF
--- a/samples/oci-adb-client-runsql-python/Dockerfile
+++ b/samples/oci-adb-client-runsql-python/Dockerfile
@@ -17,6 +17,7 @@ RUN chown -R fn:fn /tmp/dbwallet
 ENV TNS_ADMIN=/tmp/dbwallet
 
 ADD . /function/
+RUN pip3 install --upgrade pip
 RUN pip3 install --no-cache --no-cache-dir -r requirements.txt
 RUN rm -fr /function/.pip_cache ~/.cache/pip requirements.txt func.yaml Dockerfile README.md
 

--- a/samples/oci-adb-client-runsql-python/requirements.txt
+++ b/samples/oci-adb-client-runsql-python/requirements.txt
@@ -1,3 +1,3 @@
 fdk
 cx_oracle
-oci==2.40.0
+oci


### PR DESCRIPTION
Added "RUN pip3 install --upgrade pip". 
The OCI Python SDK v2.40.1+ uses updated Cryptography versions. The new Cryptography uses a newer version of setuptools which is not available in Pip. Updating Pip gives you access to download that.